### PR TITLE
remove credentials from test spec url

### DIFF
--- a/spec/responses/sasb.json
+++ b/spec/responses/sasb.json
@@ -493,7 +493,7 @@
                     },
                     "body": "Frank Bruni comes to Books at Noon next Wednesday, March 18 to discuss his latest work, Where You Go Is Not Who You\u2019ll Be: An Antidote to the College Admissions Mania. We asked him six questions about what he likes to read.",
                     "id": 292398,
-                    "image": "http://contentcafe2.btol.com/ContentCafe/Jacket.aspx?&userID=NYPL49807&password=CC68707&Value=9781455532704&content=M&Return=1&Type=M",
+                    "image": "http://contentcafe2.btol.com/ContentCafe/Jacket.aspx",
                     "pubdate": "2015-03-11T17:25:29Z",
                     "title": "Ask the Author: Frank Bruni"
                 },


### PR DESCRIPTION
Removes exposed content cafe credentials. Once this is merged I will remove the credentials from the entire git history